### PR TITLE
Ci/fix env problems

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -23,7 +23,8 @@ jobs:
       - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
       - name: Install packages
         run: dart pub install
-
+      - name: Create mock configuration files
+        run: touch .env
         
       # Formatting and analyzing
       - name: Verify formatting

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -7,7 +7,7 @@ name: Dart
 
 on:
   push:
-    branches: [ develop, feature/*, hotfix/* ]
+    branches: [ develop, feature/*, hotfix/*, ci/* ]
   pull_request:
     branches: [ develop ]
 


### PR DESCRIPTION
Fix the problem that the .env file is mentioned in the assets (of the pubspec.yaml), but at the same time also inside of the .gitignore, meaning that a default empty .env should be placed inside of the repository while testing