### PR TITLE
Ci/fix duplicate github actions 

### DIFF
--- a/.github/workflows/analyzing.yml
+++ b/.github/workflows/analyzing.yml
@@ -7,9 +7,7 @@ name: Analyzing
 
 on:
   push:
-    branches: [ feature/*, hotfix/*, ci/* ]
-  pull_request:
-    branches: [ develop ]
+    branches: [ develop, feature/*, hotfix/*, ci/* ]
 
 jobs:
   build:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -7,9 +7,7 @@ name: Formatting
 
 on:
   push:
-    branches: [ feature/*, hotfix/*, ci/* ]
-  pull_request:
-    branches: [ develop ]
+    branches: [ develop, feature/*, hotfix/*, ci/* ]
 
 jobs:
   build:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,9 +7,7 @@ name: Testing
 
 on:
   push:
-    branches: [ feature/*, hotfix/*, ci/* ]
-  pull_request:
-    branches: [ develop ]
+    branches: [ develop, feature/*, hotfix/*, ci/* ]
 
 jobs:
   build:


### PR DESCRIPTION
On a pull request to develop all GitHub actions would be duplicated, as the actions are called on a pull_request and on the branch they are on